### PR TITLE
Require Ruby 3.1 and excon 1.5.0 or newer

### DIFF
--- a/MailchimpTransactional.gemspec
+++ b/MailchimpTransactional.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |s|
   s.license     = 'Apache-2.0'
   s.required_ruby_version = ">= 1.9"
 
-  s.add_runtime_dependency 'excon', '>= 0.76.0'
+  s.add_runtime_dependency 'excon', '>= 1.5.0'
   s.add_runtime_dependency 'json', '~> 2.1', '>= 2.1.0'
 
   s.add_development_dependency 'rspec', '~> 3.6', '>= 3.6.0'

--- a/MailchimpTransactional.gemspec
+++ b/MailchimpTransactional.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |s|
   s.summary     = "Mailchimp Transactional API Ruby Gem"
   s.description = "The official Ruby client library for the Mailchimp Trainsactional API"
   s.license     = 'Apache-2.0'
-  s.required_ruby_version = ">= 1.9"
+  s.required_ruby_version = ">= 3.1.0"
 
   s.add_runtime_dependency 'excon', '>= 1.5.0'
   s.add_runtime_dependency 'json', '~> 2.1', '>= 2.1.0'

--- a/MailchimpTransactional.gemspec
+++ b/MailchimpTransactional.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |s|
   s.license     = 'Apache-2.0'
   s.required_ruby_version = ">= 1.9"
 
-  s.add_runtime_dependency 'excon', '>= 0.76.0', '<1'
+  s.add_runtime_dependency 'excon', '>= 0.76.0'
   s.add_runtime_dependency 'json', '~> 2.1', '>= 2.1.0'
 
   s.add_development_dependency 'rspec', '~> 3.6', '>= 3.6.0'


### PR DESCRIPTION
## Summary

This updates the Ruby client's dependency/support contract from:

```ruby
s.required_ruby_version = ">= 1.9"
s.add_runtime_dependency 'excon', '>= 0.76.0', '<1'
```

to:

```ruby
s.required_ruby_version = ">= 3.1.0"
s.add_runtime_dependency 'excon', '>= 1.5.0'
```

That makes `MailchimpTransactional` resolve a patched Excon version by default for consumers affected by current Excon security advisories, while keeping the gem's advertised Ruby support compatible with Excon 1.5.0's own Ruby requirement.

## Security Advisory

A downstream `bundler-audit` run reported the following issue with the previously resolved Excon version:

```text
Name: excon
Version: 0.112.0
CVE: CVE-2026-54171
GHSA: GHSA-48rx-c7pg-q66r
Criticality: Medium
URL: https://www.cve.org/CVERecord?id=CVE-2026-54171
```

The advisory solution requires updating Excon to `>= 1.5.0`.

## Why

Downstream applications that need to satisfy security auditing cannot currently combine `MailchimpTransactional` with `excon >= 1.5.0`, because the released gem pins Excon below 1.0.

This PR intentionally sets the minimum to `1.5.0` rather than only removing the `< 1` upper bound, so consumers using this branch do not need an additional application-level Excon pin to avoid vulnerable versions.

Because Excon 1.5.0 requires Ruby `>= 3.1.0`, this PR also raises `required_ruby_version` to `>= 3.1.0` so the gemspec remains internally consistent.

## Generated repo note

The README says this repository is autogenerated from `mailchimp/mailchimp-client-lib-codegen` and asks contributors to submit PRs/issues there. This direct PR is kept as a draft for discussion and for downstream testing of the exact dependency contract needed to resolve the audit finding.

This is related to mailchimp/mailchimp-client-lib-codegen#411, but is stricter: that PR removes the Excon upper bound, while this PR requires the patched Excon version directly and updates the Ruby requirement accordingly.

## Verification

- `ASDF_RUBY_VERSION=4.0.5 gem build MailchimpTransactional.gemspec`
- Scratch Bundler install using this patched checkout resolved `excon 1.5.0` from the gemspec without an explicit Excon pin.
- Scratch WebMock smoke test against `MailchimpTransactional::Client#users.ping`: passed with `excon 1.5.0`.
- Scratch `bundle exec bundle-audit check --update`: `No vulnerabilities found`.

## Notes

This changes only gemspec dependency metadata. The runtime client already uses Excon as its HTTP transport, and the smoke test verified the existing request path with Excon 1.5.0.